### PR TITLE
Normalizing and simplifying Cuda precompilation logging

### DIFF
--- a/ExternalProjects/managedCuda/ManagedCUDA/BasicTypesEnum.cs
+++ b/ExternalProjects/managedCuda/ManagedCUDA/BasicTypesEnum.cs
@@ -1156,7 +1156,12 @@ namespace ManagedCuda.BasicTypes
         /// <summary>
         /// Compute device class 8.6.
         /// </summary>
-        Compute_86 = 86
+        Compute_86 = 86,
+
+        /// <summary>
+        /// Compute device class 8.9.
+        /// </summary>
+        Compute_89 = 89
     }
 
     /// <summary>

--- a/Seq2SeqSharp/Utils/Misc.cs
+++ b/Seq2SeqSharp/Utils/Misc.cs
@@ -19,6 +19,7 @@ using Seq2SeqSharp.Tools;
 using TensorSharp;
 using M = System.Runtime.CompilerServices.MethodImplAttribute;
 using O = System.Runtime.CompilerServices.MethodImplOptions;
+using ManagedCuda;
 
 namespace Seq2SeqSharp.Utils
 {
@@ -50,6 +51,30 @@ namespace Seq2SeqSharp.Utils
         public static string GetTimeStamp(DateTime timeStamp)
         {
             return string.Format("{0:yyyy}_{0:MM}_{0:dd}_{0:HH}h_{0:mm}m_{0:ss}s", timeStamp);
+        }
+
+        /// <summary>
+        /// Get the number of GPU's or CPU cores in the system
+        /// </summary>
+        /// <param name="GPU">true: get the number of GPUs in the system (default), false: get the number of CPU cores in the system</param>
+        /// <returns>number of GPUs or CPU cores in the system</returns>
+        public static int GetDeviceCount(bool GPU = true)
+        {
+            try
+            {
+                if (GPU)
+                {
+                    return CudaContext.GetDeviceCount();
+                }
+                else
+                {
+                    return Environment.ProcessorCount;
+                }
+            }
+            catch (Exception)
+            {
+                return 0;
+            }
         }
     }
 

--- a/Seq2SeqSharp/Utils/TensorAllocator.cs
+++ b/Seq2SeqSharp/Utils/TensorAllocator.cs
@@ -42,7 +42,7 @@ namespace Seq2SeqSharp.Utils
             if (m_archType == ProcessorTypeEnums.GPU)
             {
                 m_cudaContext = new TSCudaContext(m_deviceIds, memoryUsageRatio, compilerOptions, allocatorType, elementType);
-                m_cudaContext.Precompile(Console.Write);
+                m_cudaContext.Precompile();
                 m_cudaContext.CleanUnusedPTX();
 
                 foreach (int deviceId in m_deviceIds)

--- a/TensorSharp.CUDA/PrecompileAttribute.cs
+++ b/TensorSharp.CUDA/PrecompileAttribute.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using AdvUtils;
+using System;
 using System.Reflection;
 using TensorSharp.CUDA.RuntimeCompiler;
 
@@ -28,7 +29,7 @@ namespace TensorSharp.CUDA
                 if (typeof(IPrecompilable).IsAssignableFrom(field.FieldType))
                 {
                     IPrecompilable precompilableField = (IPrecompilable)field.GetValue(instance);
-                    Console.WriteLine("Compiling field " + field.Name);
+                    Logger.WriteLine("Compiling field " + field.Name);
                     precompilableField.Precompile(compiler);
                 }
             }

--- a/TensorSharp.CUDA/TSCudaContext.cs
+++ b/TensorSharp.CUDA/TSCudaContext.cs
@@ -1,4 +1,5 @@
-﻿using ManagedCuda;
+﻿using AdvUtils;
+using ManagedCuda;
 using ManagedCuda.BasicTypes;
 using ManagedCuda.CudaBlas;
 using System;
@@ -189,18 +190,12 @@ namespace TensorSharp.CUDA
             }
         }
 
-
         public void Precompile()
-        {
-            Precompile(Console.Write);
-        }
-
-        public void Precompile(Action<string> precompileProgressWriter)
         {
             Assembly assembly = Assembly.GetExecutingAssembly();
             foreach (Tuple<Type, IEnumerable<PrecompileAttribute>> applyType in assembly.TypesWithAttribute<PrecompileAttribute>(true).Where(x => !x.Item1.IsAbstract))
             {
-                precompileProgressWriter("Precompiling " + applyType.Item1.Name + "\n");
+                Logger.WriteLine("Precompiling " + applyType.Item1.Name);
 
                 IPrecompilable instance = (IPrecompilable)Activator.CreateInstance(applyType.Item1);
                 instance.Precompile(Compiler);


### PR DESCRIPTION
Replacing Console write with Logger write. The library should not write directly to the Console. Simplification: precompileProgressWriter function is then not needed.